### PR TITLE
adapt to block errors

### DIFF
--- a/tests/block_ccm_tests.ml
+++ b/tests/block_ccm_tests.ml
@@ -11,8 +11,8 @@ let key k =
   Nocrypto.Uncommon.Cs.of_hex s
 
 let (>>|=) m f = m >>= function
-  | `Ok x -> f x
-  | `Error e -> assert_equal e `Unimplemented; return ()
+  | Ok x -> f x
+  | Error e -> assert_equal e `Unimplemented; return ()
 
 let sectors () =
   let page = (Io_page.get 1  |> Io_page.to_cstruct) in
@@ -48,7 +48,7 @@ let fail_read _ =
     CCM.connect ~nonce_len ~maclen ~key dev >>= fun ccm ->
     let s0,_ = sectors () in
     CCM.read ccm 0L [s0] >>= fun r ->
-    assert_equal r (`Error (`Unknown "decrypt error"));
+    assert_equal r (Error (`Msg "decrypt error"));
     CCM.disconnect ccm >>= fun () ->
     Fake_block.disconnect dev >>= fun () ->
     return () in

--- a/tests/fake_block.ml
+++ b/tests/fake_block.ml
@@ -19,12 +19,7 @@ module A = Bigarray.Array1
 
 type +'a io = 'a Lwt.t
 type t = Cstruct.t
-type error = [
-  | `Unknown of string (** an undiagnosed error *)
-  | `Unimplemented     (** operation not yet implemented in the code *)
-  | `Is_read_only      (** you cannot write to a read/only instance *)
-  | `Disconnected      (** the device has been previously disconnected *)
-]
+type error = V1.Block.error
 
 let sector_size = 512
 
@@ -46,10 +41,10 @@ let write device sector_start buffers =
         Cstruct.blit x 0 device dstoff (Cstruct.len x);
         loop (dstoff + (Cstruct.len x)) xs in
   loop (safe_of_int64 sector_start * sector_size) buffers;
-  `Ok () |> return
+  Ok () |> return
 
 let read device sector_start buffers =
-  if 0 = (Cstruct.len device) then return (`Error `Unimplemented)
+  if 0 = (Cstruct.len device) then return (Error `Unimplemented)
   else
     let rec loop dstoff = function
       | [] -> ()
@@ -57,7 +52,7 @@ let read device sector_start buffers =
         Cstruct.blit device dstoff x 0 (Cstruct.len x);
         loop (dstoff + (Cstruct.len x)) xs in
     loop (safe_of_int64 sector_start * sector_size) buffers;
-    `Ok () |> return
+    Ok () |> return
 
 let info = {
   read_write = true;


### PR DESCRIPTION
* consume result types from the underlying BLOCK modules over which modules are functorized
* emit result types from our own modules, rather than polyvars

These changes let `mirage-block-ccm` build against the `mirage-types` changes proposed at https://github.com/mirage/mirage/pull/705 .  If merged before that PR is merged, `mirage-block-ccm` will not build against the current master of `mirage`.