### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## mirage-block-ccm
 [![Build Status](https://travis-ci.org/sg2342/mirage-block-ccm.svg?branch=master)](https://travis-ci.org/sg2342/mirage-block-ccm)
 
-AES-CCM encrypted Mirage V1.BLOCK storage
+AES-CCM encrypted Mirage Mirage_types.BLOCK storage
 
-uses two sectors of the underlying V1.BLOCK per provided sector:
+uses two sectors of the underlying Mirage_types.BLOCK per provided sector:
 
 ```
 +-----------------------------------+

--- a/lib/block_ccm.ml
+++ b/lib/block_ccm.ml
@@ -1,6 +1,6 @@
 open Lwt
 
-module Make(B : V1_LWT.BLOCK) = struct
+module Make(B : Mirage_types_lwt.BLOCK) = struct
 
   type key = { key       : Nocrypto.Cipher_block.AES.CCM.key;
                maclen    : int;

--- a/lib/block_ccm.mli
+++ b/lib/block_ccm.mli
@@ -1,7 +1,7 @@
-module Make (B: V1.BLOCK
+module Make (B: Mirage_types.BLOCK
              with type 'a io = 'a Lwt.t
               and type page_aligned_buffer = Cstruct.t) : sig
-  include V1.BLOCK
+  include Mirage_types.BLOCK
     with type 'a io = 'a Lwt.t
      and type page_aligned_buffer = Cstruct.t
 

--- a/tests/fake_block.ml
+++ b/tests/fake_block.ml
@@ -19,7 +19,7 @@ module A = Bigarray.Array1
 
 type +'a io = 'a Lwt.t
 type t = Cstruct.t
-type error = V1.Block.error
+type error = Mirage_types.Block.error
 
 let sector_size = 512
 


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.