### PR TITLE
avoid public name for example

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -1,5 +1,4 @@
 (executable
  (name ccmblock)
- (public_name ccmblock)
  (libraries mirage-block-ccm astring cmdliner lwt.unix mirage-block-unix
    mirage-crypto-rng.unix))

--- a/mirage-block-ccm.opam
+++ b/mirage-block-ccm.opam
@@ -41,7 +41,7 @@ depends: [
   "mirage-crypto-rng"
   "ounit2" {with-test}
   "bisect_ppx" {dev}
-  "cmdliner" {>= "1.1.0"}
-  "astring"
-  "mirage-block-unix"
+  "cmdliner" {with-test & >= "1.1.0"}
+  "astring" {with-test}
+  "mirage-block-unix" {with-test}
 ]


### PR DESCRIPTION
move cmdliner, astring, and mirage-block-unix to test dependencies